### PR TITLE
Fix #31: Add QR to badge

### DIFF
--- a/projects/badge/badge.js
+++ b/projects/badge/badge.js
@@ -180,6 +180,7 @@
       minimal: renderMinimalTemplate,
       developer: renderDeveloperTemplate,
       social: renderSocialTemplate,
+      qrcode: renderQRCodeTemplate,
     };
 
     (templates[state.template] || renderConferenceTemplate)(spec);
@@ -470,6 +471,132 @@
       ctx.fillStyle = accent;
       ctx.font = '13px sans-serif';
       ctx.fillText(state.extra, 100, height / 2 + 28);
+    }
+  }
+
+  function renderQRCodeTemplate(spec) {
+    const { width, height } = spec;
+    const accent = state.accentColor;
+    const isPortrait = height > width;
+
+    // Generate QR code from extra field (handle/URL)
+    const qrContent = state.extra || state.name || 'badge';
+    let qr = null;
+    try {
+      qr = qrcode(0, 'M');
+      qr.addData(qrContent);
+      qr.make();
+    } catch (e) {
+      // Fallback for very long data
+      qr = qrcode(0, 'L');
+      qr.addData(qrContent);
+      qr.make();
+    }
+
+    const moduleCount = qr.getModuleCount();
+
+    if (isPortrait) {
+      // Top accent bar
+      ctx.fillStyle = accent;
+      ctx.fillRect(0, 0, width, 50);
+
+      // Event name in bar
+      ctx.fillStyle = '#ffffff';
+      ctx.font = 'bold 16px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText(state.company, width / 2, 32);
+
+      // Name
+      ctx.fillStyle = '#000000';
+      ctx.font = 'bold 28px sans-serif';
+      ctx.textAlign = 'center';
+      fitText(ctx, state.name, width / 2, 90, width - 40, 28);
+
+      // Title
+      ctx.fillStyle = '#444444';
+      ctx.font = '16px sans-serif';
+      fitText(ctx, state.title, width / 2, 116, width - 40, 16);
+
+      // Divider
+      ctx.fillStyle = accent;
+      ctx.fillRect(width / 2 - 30, 132, 60, 3);
+
+      // QR code - centered
+      const qrAreaSize = Math.min(width - 40, height - 220);
+      const cellSize = Math.floor(qrAreaSize / moduleCount);
+      const qrSize = cellSize * moduleCount;
+      const qrX = (width - qrSize) / 2;
+      const qrY = 150;
+
+      // White background for QR
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(qrX - 8, qrY - 8, qrSize + 16, qrSize + 16);
+
+      // Draw QR modules
+      ctx.fillStyle = '#000000';
+      for (let row = 0; row < moduleCount; row++) {
+        for (let col = 0; col < moduleCount; col++) {
+          if (qr.isDark(row, col)) {
+            ctx.fillRect(qrX + col * cellSize, qrY + row * cellSize, cellSize, cellSize);
+          }
+        }
+      }
+
+      // Extra text below QR
+      const textY = qrY + qrSize + 28;
+      ctx.fillStyle = '#555555';
+      ctx.font = '14px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText(state.extra, width / 2, textY);
+
+      // Bottom bar
+      ctx.fillStyle = accent;
+      ctx.fillRect(0, height - 30, width, 30);
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '12px sans-serif';
+      ctx.fillText('Scan me!', width / 2, height - 10);
+    } else {
+      // Landscape layout
+      ctx.fillStyle = accent;
+      ctx.fillRect(0, 0, 6, height);
+
+      // QR code on the left
+      const qrAreaSize = Math.min(height - 20, width / 2 - 20);
+      const cellSize = Math.floor(qrAreaSize / moduleCount);
+      const qrSize = cellSize * moduleCount;
+      const qrX = 16;
+      const qrY = (height - qrSize) / 2;
+
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(qrX - 4, qrY - 4, qrSize + 8, qrSize + 8);
+
+      ctx.fillStyle = '#000000';
+      for (let row = 0; row < moduleCount; row++) {
+        for (let col = 0; col < moduleCount; col++) {
+          if (qr.isDark(row, col)) {
+            ctx.fillRect(qrX + col * cellSize, qrY + row * cellSize, cellSize, cellSize);
+          }
+        }
+      }
+
+      // Text on the right
+      const textX = qrX + qrSize + 20;
+      ctx.fillStyle = '#000000';
+      ctx.font = 'bold 22px sans-serif';
+      ctx.textAlign = 'left';
+      fitText(ctx, state.name, textX, height / 2 - 20, width - textX - 12, 22);
+
+      ctx.fillStyle = '#444444';
+      ctx.font = '14px sans-serif';
+      fitText(ctx, state.title, textX, height / 2 + 4, width - textX - 12, 14);
+
+      ctx.fillStyle = '#555555';
+      ctx.font = '13px sans-serif';
+      ctx.fillText(state.company, textX, height / 2 + 24);
+
+      ctx.fillStyle = accent;
+      ctx.font = '12px sans-serif';
+      ctx.fillText(state.extra, textX, height / 2 + 44);
     }
   }
 

--- a/projects/badge/index.html
+++ b/projects/badge/index.html
@@ -425,6 +425,10 @@ input:focus, select:focus {
           <div class="template-icon">🦋</div>
           Social
         </button>
+        <button class="template-btn" data-template="qrcode">
+          <div class="template-icon">📱</div>
+          QR Code
+        </button>
       </div>
 
       <label for="badgeName">Name</label>
@@ -538,6 +542,7 @@ input:focus, select:focus {
   Inspired by <a href="https://github.com/flutter-and-friends/friends_badge" target="_blank">flutter-and-friends/friends_badge</a>
 </div>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode-generator/1.4.4/qrcode.min.js"></script>
 <script src="badge.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Added QR Code Template to Badge App

### Changes
- **New "QR Code" template** added to the badge designer with both portrait and landscape layouts
- **Portrait mode**: Shows accent bar with company name, name, title, centered QR code, extra text, and a "Scan me!" bottom bar
- **Landscape mode**: QR code on the left side with name, title, company, and extra text on the right
- **QR code content**: Generated from the "Extra Line" field (e.g. `@flutterdev`, a URL, etc.)
- **Library**: Uses [qrcode-generator](https://github.com/nicennnnnnnlee/qrcode-generator) (1.4.4) loaded from cdnjs CDN

### Files modified
- `projects/badge/index.html` — Added QR template button (📱 icon) and qrcode-generator script
- `projects/badge/badge.js` — Added `renderQRCodeTemplate()` function with portrait/landscape support

### How to test
1. Open the badge app
2. Select the "QR Code" template from the template grid
3. Enter text in the "Extra Line" field (URL, handle, etc.) — this becomes the QR code content
4. Preview updates live; works with all badge sizes, orientations, palettes, and dithering options

---
*Created by Claude agent*