### PR TITLE
Fix #33: Update QR

### DIFF
--- a/issues/issue-33.md
+++ b/issues/issue-33.md
@@ -1,0 +1,14 @@
+# Issue #33: Update QR
+
+**Status:** Fixed
+
+## Problem
+1. No obvious way to set QR code content - users couldn't find where to enter the QR URL/text
+2. QR codes couldn't be scanned on Android - dithering algorithm was corrupting the QR modules
+
+## Fix
+- Added a dedicated "QR Code Content" input field that appears when the QR Code template is selected
+- Disabled dithering for the QR code template (QR codes must be crisp black/white to be scannable)
+- Added proper quiet zone (4-module white border) around QR codes per QR spec
+- Ensured minimum cell size (3px portrait, 2px landscape) for reliable scanning
+- Changed to error correction level L for simpler QR codes with larger cells

--- a/projects/badge/badge.js
+++ b/projects/badge/badge.js
@@ -36,6 +36,7 @@
     title: 'Mobile Engineer',
     company: 'Flutter & Friends',
     extra: '@flutterdev',
+    qrContent: '',
     accentColor: '#e94560',
     palette: 'bwyr',
     dither: 'floydSteinberg',
@@ -185,11 +186,14 @@
 
     (templates[state.template] || renderConferenceTemplate)(spec);
 
-    // Apply dithering
-    const palette = PALETTES[state.palette];
-    const imageData = ctx.getImageData(0, 0, spec.width, spec.height);
-    ditherImage(imageData, palette, state.dither);
-    ctx.putImageData(imageData, 0, 0);
+    // Skip dithering for QR code template - dithering corrupts QR modules
+    // making the code unscannable. QR codes are already pure black & white.
+    if (state.template !== 'qrcode') {
+      const palette = PALETTES[state.palette];
+      const imageData = ctx.getImageData(0, 0, spec.width, spec.height);
+      ditherImage(imageData, palette, state.dither);
+      ctx.putImageData(imageData, 0, 0);
+    }
   }
 
   function renderConferenceTemplate(spec) {
@@ -479,15 +483,16 @@
     const accent = state.accentColor;
     const isPortrait = height > width;
 
-    // Generate QR code from extra field (handle/URL)
-    const qrContent = state.extra || state.name || 'badge';
+    // Generate QR code from dedicated qrContent field, falling back to extra field
+    const qrContent = state.qrContent || state.extra || state.name || 'badge';
     let qr = null;
     try {
-      qr = qrcode(0, 'M');
+      // Use error correction level L for smaller QR (larger cells = easier scanning)
+      qr = qrcode(0, 'L');
       qr.addData(qrContent);
       qr.make();
     } catch (e) {
-      // Fallback for very long data
+      // Fallback: let library auto-select version
       qr = qrcode(0, 'L');
       qr.addData(qrContent);
       qr.make();
@@ -521,16 +526,19 @@
       ctx.fillStyle = accent;
       ctx.fillRect(width / 2 - 30, 132, 60, 3);
 
-      // QR code - centered
-      const qrAreaSize = Math.min(width - 40, height - 220);
-      const cellSize = Math.floor(qrAreaSize / moduleCount);
+      // QR code - centered, with adequate quiet zone for scanning
+      const quietZone = 4; // modules of quiet zone (QR spec requires >= 4)
+      const qrAreaSize = Math.min(width - 20, height - 220);
+      const cellSize = Math.max(3, Math.floor(qrAreaSize / (moduleCount + quietZone * 2)));
       const qrSize = cellSize * moduleCount;
+      const totalQrSize = cellSize * (moduleCount + quietZone * 2);
       const qrX = (width - qrSize) / 2;
       const qrY = 150;
 
-      // White background for QR
+      // White background for QR with quiet zone
       ctx.fillStyle = '#ffffff';
-      ctx.fillRect(qrX - 8, qrY - 8, qrSize + 16, qrSize + 16);
+      const quietPx = cellSize * quietZone;
+      ctx.fillRect(qrX - quietPx, qrY - quietPx, qrSize + quietPx * 2, qrSize + quietPx * 2);
 
       // Draw QR modules
       ctx.fillStyle = '#000000';
@@ -560,15 +568,17 @@
       ctx.fillStyle = accent;
       ctx.fillRect(0, 0, 6, height);
 
-      // QR code on the left
-      const qrAreaSize = Math.min(height - 20, width / 2 - 20);
-      const cellSize = Math.floor(qrAreaSize / moduleCount);
+      // QR code on the left with proper quiet zone
+      const quietZoneL = 4;
+      const qrAreaSize = Math.min(height - 16, width / 2 - 20);
+      const cellSize = Math.max(2, Math.floor(qrAreaSize / (moduleCount + quietZoneL * 2)));
       const qrSize = cellSize * moduleCount;
       const qrX = 16;
       const qrY = (height - qrSize) / 2;
 
+      const quietPxL = cellSize * quietZoneL;
       ctx.fillStyle = '#ffffff';
-      ctx.fillRect(qrX - 4, qrY - 4, qrSize + 8, qrSize + 8);
+      ctx.fillRect(qrX - quietPxL, qrY - quietPxL, qrSize + quietPxL * 2, qrSize + quietPxL * 2);
 
       ctx.fillStyle = '#000000';
       for (let row = 0; row < moduleCount; row++) {
@@ -983,6 +993,9 @@
         btn.classList.add('active');
         state.template = btn.dataset.template;
         state.mode = 'template';
+        // Show/hide QR content input
+        document.getElementById('qrContentGroup').style.display =
+          state.template === 'qrcode' ? 'block' : 'none';
         render();
       });
     });
@@ -995,6 +1008,12 @@
         state[key] = el.value;
         if (state.mode === 'template') render();
       });
+    });
+
+    // QR content input
+    document.getElementById('qrContent').addEventListener('input', (e) => {
+      state.qrContent = e.target.value;
+      if (state.mode === 'template' && state.template === 'qrcode') render();
     });
 
     // Accent color

--- a/projects/badge/index.html
+++ b/projects/badge/index.html
@@ -443,6 +443,12 @@ input:focus, select:focus {
       <label for="badgeExtra">Extra Line</label>
       <input type="text" id="badgeExtra" placeholder="@handle or hashtag" value="@flutterdev">
 
+      <div id="qrContentGroup" style="display:none;">
+        <label for="qrContent">QR Code Content (URL or text)</label>
+        <input type="text" id="qrContent" placeholder="https://example.com or any text" value="">
+        <p style="font-size:0.75rem; color:var(--text-dim); margin-top:4px;">This is what gets encoded in the QR code. Leave empty to use the Extra Line.</p>
+      </div>
+
       <label>Accent Color</label>
       <div class="color-row">
         <button class="color-btn active" data-color="#e94560" style="background:#e94560" title="Red"></button>


### PR DESCRIPTION
## Fix #33: QR Code Scanning & Content Input

### Problems Fixed
1. **No obvious way to set QR content** — The QR code template was silently using the "Extra Line" field, which wasn't discoverable.
2. **QR codes couldn't be scanned on Android** — The dithering algorithm was applied to the entire badge canvas, including the QR code, corrupting the precise black/white QR modules and making them unreadable.

### Changes Made

**`projects/badge/index.html`**
- Added a dedicated **"QR Code Content"** input field with a clear label that appears when the QR Code template is selected

**`projects/badge/badge.js`**
- Added `qrContent` state field and input handler
- Show/hide the QR content input when switching templates
- **Disabled dithering for QR code template** — QR codes require crisp black & white modules; dithering was the root cause of scan failures
- Added proper **4-module quiet zone** (white border) around QR codes per QR specification
- Enforced **minimum cell size** (3px portrait, 2px landscape) for reliable scanning
- Changed error correction to level **L** for simpler QR codes with larger individual cells

### How to Test
1. Go to the badge editor and select the **QR Code** template
2. A new "QR Code Content" input appears — enter a URL or text
3. The QR code preview should be crisp black & white (no dithering artifacts)
4. Download the PNG and verify it scans on Android

---
*Created by Claude agent*