### PR TITLE
Fix red color not showing on QR code badge template

### DIFF
--- a/projects/badge/badge.js
+++ b/projects/badge/badge.js
@@ -893,16 +893,21 @@
     const outputSize = Math.ceil(totalPixels / 4);
     const output = new Uint8Array(outputSize);
 
+    // BWYR palette for closest-color matching (handles non-dithered pixels too)
+    const bwyrPalette = PALETTES.bwyr;
+
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const idx = (y * width + x) * 4;
         const r = data[idx], g = data[idx + 1], b = data[idx + 2];
 
-        const luminance = r * 0.3 + g * 0.59 + b * 0.11;
-        let colorValue = luminance <= 95 ? 0 : 1;
-
-        if (r > 95 && g > 95 && b < 95) colorValue = 2; // Yellow
-        else if (r > 95 && g < 95 && b < 95) colorValue = 3; // Red
+        const closest = findClosestColor(r, g, b, bwyrPalette);
+        // Map palette entry to 2-bit value: Black=0, White=1, Yellow=2, Red=3
+        let colorValue;
+        if (closest[0] === 0) colorValue = 0;           // Black
+        else if (closest[1] === 255 && closest[2] === 255) colorValue = 1; // White
+        else if (closest[1] === 255) colorValue = 2;     // Yellow
+        else colorValue = 3;                              // Red
 
         // Column-major: 4 horizontal pixels per byte, 416 bytes per column-group
         const outIdx = (x >> 2) * height + y;


### PR DESCRIPTION
## Summary
- QR code template skips dithering to keep QR modules scannable, but this meant the accent color `#e94560` (B=96) bypassed palette snapping
- The old threshold check `b < 95` in `convertBWYR` failed by 1 for this color, classifying red as white
- Replaced fragile luminance/threshold checks with `findClosestColor` using the BWYR palette for robust color mapping of any input color

## Test plan
- [ ] Select QR code template with red accent color, verify red bars/dividers appear on device
- [ ] Verify yellow accent color still works correctly
- [ ] Verify other templates (conference, social, etc.) still render correctly on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)