### PR TITLE
Fix #39: Change flutter_demo into dark mode

### DIFF
--- a/projects/flutter_demo/lib/app.dart
+++ b/projects/flutter_demo/lib/app.dart
@@ -16,7 +16,11 @@ class MyApp extends StatelessWidget {
       child: MaterialApp(
         title: 'Flutter Demo',
         theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.deepPurple,
+            brightness: Brightness.dark,
+          ),
+          brightness: Brightness.dark,
         ),
         home: const CounterPage(title: 'Flutter Demo Home Page'),
       ),


### PR DESCRIPTION
## Changed flutter_demo to dark mode

Updated `projects/flutter_demo/lib/app.dart` to use a dark theme:

- Set `brightness: Brightness.dark` on both the `ColorScheme.fromSeed()` and the top-level `ThemeData`
- The seed color (`Colors.deepPurple`) is preserved, so the purple accent carries over into dark mode

**Changed file:** `lib/app.dart`

```dart
theme: ThemeData(
  colorScheme: ColorScheme.fromSeed(
    seedColor: Colors.deepPurple,
    brightness: Brightness.dark,
  ),
  brightness: Brightness.dark,
),
```

---
*Created by Claude agent*