### PR TITLE
Fix #43: Add tooltip

### DIFF
--- a/projects/badge/index.html
+++ b/projects/badge/index.html
@@ -527,7 +527,7 @@ input:focus, select:focus {
     <h2>Send to Badge</h2>
     <div id="bleSupported">
       <div class="ble-row">
-        <button class="btn btn-primary" id="bleConnectBtn">Connect Badge</button>
+        <button class="btn btn-primary" id="bleConnectBtn" title="Activate by reading NFC">Connect Badge</button>
         <button class="btn btn-secondary" id="bleSendBtn" disabled>Write to Badge</button>
         <div class="status-indicator">
           <span class="status-dot" id="statusDot"></span>


### PR DESCRIPTION
Added a `title="Activate by reading NFC"` tooltip to the **Connect Badge** button in `projects/badge/index.html`.

When users hover over the "Connect Badge" button, they'll now see the tooltip text "Activate by reading NFC".

---
*Created by Claude agent*