### PR TITLE
Fix #46: Move "activate by ..."

### DIFF
--- a/projects/badge/index.html
+++ b/projects/badge/index.html
@@ -564,10 +564,10 @@ input:focus, select:focus {
 
   <!-- BLE Section -->
   <div class="panel ble-section">
-    <h2>Send to Badge</h2>
+    <h2>Send to Badge <span style="font-size:0.65rem; text-transform:none; letter-spacing:0; font-weight:400; color:var(--text-dim);">(Activate by reading NFC)</span></h2>
     <div id="bleSupported">
       <div class="ble-row">
-        <button class="btn btn-primary" id="bleConnectBtn" title="Activate by reading NFC">Connect Badge</button>
+        <button class="btn btn-primary" id="bleConnectBtn">Connect Badge</button>
         <button class="btn btn-secondary" id="bleSendBtn" disabled>Write to Badge</button>
         <div class="status-indicator">
           <span class="status-dot" id="statusDot"></span>


### PR DESCRIPTION
## Summary

Moved the "Activate by reading NFC" text from the tooltip (`title` attribute) on the "Connect Badge" button to display inline after the "SEND TO BADGE" heading, in smaller text and parentheses.

### Changes
- **`projects/badge/index.html`**: 
  - Removed `title="Activate by reading NFC"` from the Connect Badge button
  - Added `(Activate by reading NFC)` as a smaller, inline `<span>` after the "Send to Badge" `<h2>` heading — styled with reduced font size, normal weight, and dimmed color to keep it subtle

---
*Created by Claude agent*