### PR TITLE
Fix #48: Badge - Text item colors

### DIFF
--- a/issues/issue-48.md
+++ b/issues/issue-48.md
@@ -1,0 +1,10 @@
+# Issue #48: Badge - Text item colors
+
+## Status: Complete
+
+## Changes
+- Added per-text-item color pickers (text color + background color) next to each text input field
+- Each of the 4 text items (Name, Title, Company, Extra) now has two color inputs: Text and Bg
+- Mix template's `drawMixTextItem` now uses per-item `bgColor` instead of forced white
+- Accent color button still syncs Company and Extra text colors by default
+- State tracks `itemColors` with per-item text and bg colors

--- a/projects/badge/badge.js
+++ b/projects/badge/badge.js
@@ -42,6 +42,12 @@
     qrContent: '',
     qrScalePercent: 50,
     accentColor: '#e94560',
+    itemColors: {
+      name:    { text: '#000000', bg: '#ffffff' },
+      title:   { text: '#333333', bg: '#ffffff' },
+      company: { text: '#e94560', bg: '#ffffff' },
+      extra:   { text: '#e94560', bg: '#ffffff' },
+    },
     palette: 'bwyr',
     dither: 'floydSteinberg',
     sizeKey: '240x416',
@@ -262,7 +268,7 @@
   function getMixTextItems(spec) {
     const { width, height } = spec;
     const isPortrait = height > width;
-    const accent = state.accentColor;
+    const ic = state.itemColors;
     const layout = getMixLayoutBucket();
 
     const defaults = isPortrait
@@ -277,7 +283,8 @@
             maxWidth: width - 24,
             fontSize: 16,
             font: 'bold 16px sans-serif',
-            color: accent,
+            color: ic.company.text,
+            bgColor: ic.company.bg,
           },
           {
             key: 'name',
@@ -289,7 +296,8 @@
             maxWidth: width - 24,
             fontSize: 34,
             font: 'bold 34px sans-serif',
-            color: '#000000',
+            color: ic.name.text,
+            bgColor: ic.name.bg,
           },
           {
             key: 'title',
@@ -301,7 +309,8 @@
             maxWidth: width - 24,
             fontSize: 18,
             font: '18px sans-serif',
-            color: '#333333',
+            color: ic.title.text,
+            bgColor: ic.title.bg,
           },
           {
             key: 'extra',
@@ -313,7 +322,8 @@
             maxWidth: width - 24,
             fontSize: 16,
             font: '16px sans-serif',
-            color: accent,
+            color: ic.extra.text,
+            bgColor: ic.extra.bg,
           },
         ]
       : [
@@ -327,7 +337,8 @@
             maxWidth: width - 24,
             fontSize: 14,
             font: 'bold 14px sans-serif',
-            color: accent,
+            color: ic.company.text,
+            bgColor: ic.company.bg,
           },
           {
             key: 'name',
@@ -339,7 +350,8 @@
             maxWidth: width - 24,
             fontSize: 28,
             font: 'bold 28px sans-serif',
-            color: '#000000',
+            color: ic.name.text,
+            bgColor: ic.name.bg,
           },
           {
             key: 'title',
@@ -351,7 +363,8 @@
             maxWidth: width - 24,
             fontSize: 16,
             font: '16px sans-serif',
-            color: '#333333',
+            color: ic.title.text,
+            bgColor: ic.title.bg,
           },
           {
             key: 'extra',
@@ -363,7 +376,8 @@
             maxWidth: width - 24,
             fontSize: 14,
             font: '14px sans-serif',
-            color: accent,
+            color: ic.extra.text,
+            bgColor: ic.extra.bg,
           },
         ];
 
@@ -953,7 +967,7 @@
     const renderMetrics = getMixTextRenderMetrics(item);
     ctx.font = item.font.replace(/\d+px/, renderMetrics.fittedSize + 'px');
 
-    ctx.fillStyle = '#ffffff';
+    ctx.fillStyle = item.bgColor || '#ffffff';
     ctx.fillRect(
       renderMetrics.rectX,
       renderMetrics.rectY,
@@ -1457,7 +1471,26 @@
         document.querySelectorAll('.color-btn').forEach((b) => b.classList.remove('active'));
         btn.classList.add('active');
         state.accentColor = btn.dataset.color;
+        // Sync accent-linked item color pickers
+        const accentItems = ['company', 'extra'];
+        accentItems.forEach((key) => {
+          state.itemColors[key].text = btn.dataset.color;
+          const picker = document.getElementById(key + 'TextColor');
+          if (picker) picker.value = btn.dataset.color;
+        });
         render();
+      });
+    });
+
+    // Per-item color pickers (text & background)
+    document.querySelectorAll('.item-color-picker').forEach((picker) => {
+      picker.addEventListener('input', () => {
+        const itemKey = picker.dataset.item;
+        const kind = picker.dataset.kind;
+        if (state.itemColors[itemKey]) {
+          state.itemColors[itemKey][kind] = picker.value;
+          if (state.mode === 'template') render();
+        }
       });
     });
 

--- a/projects/badge/index.html
+++ b/projects/badge/index.html
@@ -169,6 +169,60 @@ input[type="text"], select {
   outline: none;
   transition: border 0.2s;
 }
+
+/* Text item color pickers */
+.input-with-colors {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.input-with-colors input[type="text"] {
+  flex: 1;
+  min-width: 0;
+}
+.item-color-group {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.item-color-picker {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 1px;
+  cursor: pointer;
+  background: var(--bg);
+  -webkit-appearance: none;
+  appearance: none;
+}
+.item-color-picker::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+.item-color-picker::-webkit-color-swatch {
+  border: none;
+  border-radius: 4px;
+}
+.item-color-picker::-moz-color-swatch {
+  border: none;
+  border-radius: 4px;
+}
+.item-color-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.item-color-labels {
+  display: flex;
+  gap: 4px;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+}
+.item-color-labels span {
+  width: 28px;
+  text-align: center;
+}
 input:focus, select:focus {
   border-color: var(--accent);
 }
@@ -460,17 +514,53 @@ input:focus, select:focus {
         </button>
       </div>
 
-      <label for="badgeName">Name</label>
-      <input type="text" id="badgeName" placeholder="Your Name" value="Flutter Dev">
+      <div class="item-color-label-row">
+        <label for="badgeName">Name</label>
+        <div class="item-color-labels"><span>Text</span><span>Bg</span></div>
+      </div>
+      <div class="input-with-colors">
+        <input type="text" id="badgeName" placeholder="Your Name" value="Flutter Dev">
+        <div class="item-color-group">
+          <input type="color" class="item-color-picker" id="nameTextColor" data-item="name" data-kind="text" value="#000000" title="Text color">
+          <input type="color" class="item-color-picker" id="nameBgColor" data-item="name" data-kind="bg" value="#ffffff" title="Background color">
+        </div>
+      </div>
 
-      <label for="badgeTitle">Title / Role</label>
-      <input type="text" id="badgeTitle" placeholder="Flutter Developer" value="Mobile Engineer">
+      <div class="item-color-label-row">
+        <label for="badgeTitle">Title / Role</label>
+        <div class="item-color-labels"><span>Text</span><span>Bg</span></div>
+      </div>
+      <div class="input-with-colors">
+        <input type="text" id="badgeTitle" placeholder="Flutter Developer" value="Mobile Engineer">
+        <div class="item-color-group">
+          <input type="color" class="item-color-picker" id="titleTextColor" data-item="title" data-kind="text" value="#333333" title="Text color">
+          <input type="color" class="item-color-picker" id="titleBgColor" data-item="title" data-kind="bg" value="#ffffff" title="Background color">
+        </div>
+      </div>
 
-      <label for="badgeCompany">Company / Event</label>
-      <input type="text" id="badgeCompany" placeholder="Flutter & Friends 2025" value="Flutter & Friends">
+      <div class="item-color-label-row">
+        <label for="badgeCompany">Company / Event</label>
+        <div class="item-color-labels"><span>Text</span><span>Bg</span></div>
+      </div>
+      <div class="input-with-colors">
+        <input type="text" id="badgeCompany" placeholder="Flutter & Friends 2025" value="Flutter & Friends">
+        <div class="item-color-group">
+          <input type="color" class="item-color-picker" id="companyTextColor" data-item="company" data-kind="text" value="#e94560" title="Text color">
+          <input type="color" class="item-color-picker" id="companyBgColor" data-item="company" data-kind="bg" value="#ffffff" title="Background color">
+        </div>
+      </div>
 
-      <label for="badgeExtra">Extra Line</label>
-      <input type="text" id="badgeExtra" placeholder="@handle or hashtag" value="@flutterdev">
+      <div class="item-color-label-row">
+        <label for="badgeExtra">Extra Line</label>
+        <div class="item-color-labels"><span>Text</span><span>Bg</span></div>
+      </div>
+      <div class="input-with-colors">
+        <input type="text" id="badgeExtra" placeholder="@handle or hashtag" value="@flutterdev">
+        <div class="item-color-group">
+          <input type="color" class="item-color-picker" id="extraTextColor" data-item="extra" data-kind="text" value="#e94560" title="Text color">
+          <input type="color" class="item-color-picker" id="extraBgColor" data-item="extra" data-kind="bg" value="#ffffff" title="Background color">
+        </div>
+      </div>
 
       <label>Optional Background Image</label>
       <div class="upload-zone" id="templateBgUploadZone">


### PR DESCRIPTION
## Summary

Added per-text-item color pickers (text color + background color) to the Badge editor.

### Changes

- **HTML (`index.html`)**: Each of the 4 text input fields (Name, Title, Company/Event, Extra Line) now has two compact color picker inputs to the right — one for **Text** color and one for **Bg** (background) color. Labels above indicate which is which.

- **JS (`badge.js`)**:
  - Added `itemColors` to state, tracking `{ text, bg }` colors per item (name, title, company, extra)
  - `getMixTextItems()` now reads colors from `state.itemColors` instead of hardcoded values
  - `drawMixTextItem()` uses `item.bgColor` instead of forced `#ffffff` white background
  - Accent color button still syncs Company and Extra text colors for convenience
  - New event handlers wire up all `.item-color-picker` inputs to update state and re-render

### Defaults
| Item | Text Color | Bg Color |
|------|-----------|----------|
| Name | `#000000` (black) | `#ffffff` (white) |
| Title | `#333333` (dark gray) | `#ffffff` (white) |
| Company | `#e94560` (accent) | `#ffffff` (white) |
| Extra | `#e94560` (accent) | `#ffffff` (white) |

### How to test
1. Open the badge editor and select the **Mix** template
2. Each text field should show two color pickers to its right
3. Changing text/bg colors should update the Mix template preview in real-time
4. Changing the accent color should still update Company and Extra text colors

---
*Created by Claude agent*