### PR TITLE
Fix #50: Fix badge color selection

### DIFF
--- a/issues/issue-50.md
+++ b/issues/issue-50.md
@@ -1,0 +1,13 @@
+# Issue #50: Fix badge color selection
+
+## Status: Done
+
+## Problem
+Color selection for text items in the badge editor used `<input type="color">` which allowed any arbitrary color, but the e-paper badge only supports a limited color palette (BW, BWR, or BWYR).
+
+## Solution
+- Replaced `<input type="color">` pickers with custom palette-constrained color swatches
+- Clicking a swatch opens a popup showing only the colors available in the current palette
+- When the palette changes, all selected colors snap to the nearest available palette color
+- Accent color row also dynamically updates to show only palette-available colors
+- Initial default colors updated from non-palette values (e.g. `#e94560`) to actual palette colors (e.g. `#ff0000`)

--- a/projects/badge/badge.js
+++ b/projects/badge/badge.js
@@ -32,6 +32,111 @@
   const MIX_TEXT_CHIP_PADDING_X = 6;
   const MIX_TEXT_CHIP_PADDING_Y = 4;
 
+  // ─── Palette color helpers ───
+  function rgbToHex(r, g, b) {
+    return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+  }
+
+  function hexToRgb(hex) {
+    const m = hex.match(/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+    return m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)] : [0, 0, 0];
+  }
+
+  function getPaletteHexColors() {
+    return PALETTES[state.palette].map(([r, g, b]) => rgbToHex(r, g, b));
+  }
+
+  function snapToNearestPaletteColor(hex) {
+    const [r, g, b] = hexToRgb(hex);
+    const palette = PALETTES[state.palette];
+    let bestDist = Infinity;
+    let bestColor = palette[0];
+    for (const [pr, pg, pb] of palette) {
+      const dist = (r - pr) ** 2 + (g - pg) ** 2 + (b - pb) ** 2;
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestColor = [pr, pg, pb];
+      }
+    }
+    return rgbToHex(...bestColor);
+  }
+
+  function updateSwatchColor(swatch, hex) {
+    swatch.style.background = hex;
+    const itemKey = swatch.dataset.item;
+    const kind = swatch.dataset.kind;
+    if (state.itemColors[itemKey]) {
+      state.itemColors[itemKey][kind] = hex;
+    }
+  }
+
+  function buildPalettePopup(swatch) {
+    const popup = swatch.querySelector('.palette-popup');
+    popup.innerHTML = '';
+    const colors = getPaletteHexColors();
+    const currentColor = state.itemColors[swatch.dataset.item]?.[swatch.dataset.kind] || '#000000';
+    colors.forEach(hex => {
+      const sw = document.createElement('div');
+      sw.className = 'palette-popup-swatch' + (hex === currentColor ? ' selected' : '');
+      sw.style.background = hex;
+      if (hex === '#000000' || hex === '#000') {
+        sw.style.border = '2px solid #555';
+        if (hex === currentColor) sw.style.borderColor = 'var(--accent)';
+      }
+      sw.addEventListener('click', (e) => {
+        e.stopPropagation();
+        updateSwatchColor(swatch, hex);
+        popup.classList.remove('open');
+        swatch.classList.remove('active-pick');
+        if (state.mode === 'template') render();
+      });
+      popup.appendChild(sw);
+    });
+  }
+
+  function refreshAllSwatches() {
+    document.querySelectorAll('.item-color-swatch').forEach(swatch => {
+      const itemKey = swatch.dataset.item;
+      const kind = swatch.dataset.kind;
+      if (state.itemColors[itemKey]) {
+        const snapped = snapToNearestPaletteColor(state.itemColors[itemKey][kind]);
+        state.itemColors[itemKey][kind] = snapped;
+        swatch.style.background = snapped;
+      }
+    });
+    // Also snap the accent color
+    state.accentColor = snapToNearestPaletteColor(state.accentColor);
+    rebuildAccentRow();
+  }
+
+  function rebuildAccentRow() {
+    const row = document.getElementById('accentColorRow');
+    if (!row) return;
+    row.innerHTML = '';
+    const colors = getPaletteHexColors();
+    colors.forEach(hex => {
+      const btn = document.createElement('button');
+      btn.className = 'color-btn' + (hex === state.accentColor ? ' active' : '');
+      btn.dataset.color = hex;
+      btn.style.background = hex;
+      if (hex === '#000000') btn.style.border = '1px solid #555';
+      btn.addEventListener('click', () => {
+        row.querySelectorAll('.color-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        state.accentColor = hex;
+        // Sync accent-linked item color swatches
+        const accentItems = ['company', 'extra'];
+        accentItems.forEach((key) => {
+          state.itemColors[key].text = hex;
+          const swatch = document.getElementById(key + 'TextColor');
+          if (swatch) swatch.style.background = hex;
+        });
+        render();
+      });
+      row.appendChild(btn);
+    });
+  }
+
   // ─── State ───
   const state = {
     template: 'conference',
@@ -41,12 +146,12 @@
     extra: '@flutterdev',
     qrContent: '',
     qrScalePercent: 50,
-    accentColor: '#e94560',
+    accentColor: '#ff0000',
     itemColors: {
       name:    { text: '#000000', bg: '#ffffff' },
-      title:   { text: '#333333', bg: '#ffffff' },
-      company: { text: '#e94560', bg: '#ffffff' },
-      extra:   { text: '#e94560', bg: '#ffffff' },
+      title:   { text: '#000000', bg: '#ffffff' },
+      company: { text: '#ff0000', bg: '#ffffff' },
+      extra:   { text: '#ff0000', bg: '#ffffff' },
     },
     palette: 'bwyr',
     dither: 'floydSteinberg',
@@ -1471,27 +1576,44 @@
         document.querySelectorAll('.color-btn').forEach((b) => b.classList.remove('active'));
         btn.classList.add('active');
         state.accentColor = btn.dataset.color;
-        // Sync accent-linked item color pickers
+        // Sync accent-linked item color swatches
+        const accentColor = snapToNearestPaletteColor(btn.dataset.color);
         const accentItems = ['company', 'extra'];
         accentItems.forEach((key) => {
-          state.itemColors[key].text = btn.dataset.color;
-          const picker = document.getElementById(key + 'TextColor');
-          if (picker) picker.value = btn.dataset.color;
+          state.itemColors[key].text = accentColor;
+          const swatch = document.getElementById(key + 'TextColor');
+          if (swatch) swatch.style.background = accentColor;
         });
         render();
       });
     });
 
-    // Per-item color pickers (text & background)
-    document.querySelectorAll('.item-color-picker').forEach((picker) => {
-      picker.addEventListener('input', () => {
-        const itemKey = picker.dataset.item;
-        const kind = picker.dataset.kind;
-        if (state.itemColors[itemKey]) {
-          state.itemColors[itemKey][kind] = picker.value;
-          if (state.mode === 'template') render();
-        }
+    // Per-item palette color swatches (text & background)
+    document.querySelectorAll('.item-color-swatch').forEach((swatch) => {
+      buildPalettePopup(swatch);
+      swatch.addEventListener('click', (e) => {
+        // Close any other open popups
+        document.querySelectorAll('.palette-popup.open').forEach(p => {
+          if (p.parentElement !== swatch) {
+            p.classList.remove('open');
+            p.parentElement.classList.remove('active-pick');
+          }
+        });
+        const popup = swatch.querySelector('.palette-popup');
+        buildPalettePopup(swatch);
+        popup.classList.toggle('open');
+        swatch.classList.toggle('active-pick');
       });
+    });
+
+    // Close palette popups on outside click
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.item-color-swatch')) {
+        document.querySelectorAll('.palette-popup.open').forEach(p => {
+          p.classList.remove('open');
+          p.parentElement.classList.remove('active-pick');
+        });
+      }
     });
 
     // Image upload
@@ -1545,6 +1667,8 @@
         document.querySelectorAll('.palette-btn').forEach((b) => b.classList.remove('active'));
         btn.classList.add('active');
         state.palette = btn.dataset.palette;
+        // Snap all item colors to the new palette and rebuild popups
+        refreshAllSwatches();
         render();
       });
     });

--- a/projects/badge/index.html
+++ b/projects/badge/index.html
@@ -186,27 +186,52 @@ input[type="text"], select {
   align-items: center;
   flex-shrink: 0;
 }
-.item-color-picker {
+.item-color-swatch {
   width: 28px;
   height: 28px;
-  border: 1px solid #444;
+  border: 2px solid #444;
   border-radius: 6px;
-  padding: 1px;
   cursor: pointer;
-  background: var(--bg);
-  -webkit-appearance: none;
-  appearance: none;
+  position: relative;
+  transition: border-color 0.2s, transform 0.1s;
 }
-.item-color-picker::-webkit-color-swatch-wrapper {
-  padding: 0;
+.item-color-swatch:hover {
+  transform: scale(1.1);
 }
-.item-color-picker::-webkit-color-swatch {
-  border: none;
+.item-color-swatch.active-pick {
+  border-color: var(--accent);
+}
+.palette-popup {
+  display: none;
+  position: absolute;
+  bottom: 34px;
+  right: 0;
+  background: var(--surface);
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 6px;
+  gap: 4px;
+  z-index: 100;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  flex-wrap: wrap;
+  min-width: 40px;
+}
+.palette-popup.open {
+  display: flex;
+}
+.palette-popup-swatch {
+  width: 24px;
+  height: 24px;
   border-radius: 4px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.1s, border-color 0.2s;
 }
-.item-color-picker::-moz-color-swatch {
-  border: none;
-  border-radius: 4px;
+.palette-popup-swatch:hover {
+  transform: scale(1.15);
+}
+.palette-popup-swatch.selected {
+  border-color: var(--accent);
 }
 .item-color-label-row {
   display: flex;
@@ -521,8 +546,8 @@ input:focus, select:focus {
       <div class="input-with-colors">
         <input type="text" id="badgeName" placeholder="Your Name" value="Flutter Dev">
         <div class="item-color-group">
-          <input type="color" class="item-color-picker" id="nameTextColor" data-item="name" data-kind="text" value="#000000" title="Text color">
-          <input type="color" class="item-color-picker" id="nameBgColor" data-item="name" data-kind="bg" value="#ffffff" title="Background color">
+          <div class="item-color-swatch" id="nameTextColor" data-item="name" data-kind="text" style="background:#000000" title="Text color"><div class="palette-popup"></div></div>
+          <div class="item-color-swatch" id="nameBgColor" data-item="name" data-kind="bg" style="background:#ffffff" title="Background color"><div class="palette-popup"></div></div>
         </div>
       </div>
 
@@ -533,8 +558,8 @@ input:focus, select:focus {
       <div class="input-with-colors">
         <input type="text" id="badgeTitle" placeholder="Flutter Developer" value="Mobile Engineer">
         <div class="item-color-group">
-          <input type="color" class="item-color-picker" id="titleTextColor" data-item="title" data-kind="text" value="#333333" title="Text color">
-          <input type="color" class="item-color-picker" id="titleBgColor" data-item="title" data-kind="bg" value="#ffffff" title="Background color">
+          <div class="item-color-swatch" id="titleTextColor" data-item="title" data-kind="text" style="background:#000000" title="Text color"><div class="palette-popup"></div></div>
+          <div class="item-color-swatch" id="titleBgColor" data-item="title" data-kind="bg" style="background:#ffffff" title="Background color"><div class="palette-popup"></div></div>
         </div>
       </div>
 
@@ -545,8 +570,8 @@ input:focus, select:focus {
       <div class="input-with-colors">
         <input type="text" id="badgeCompany" placeholder="Flutter & Friends 2025" value="Flutter & Friends">
         <div class="item-color-group">
-          <input type="color" class="item-color-picker" id="companyTextColor" data-item="company" data-kind="text" value="#e94560" title="Text color">
-          <input type="color" class="item-color-picker" id="companyBgColor" data-item="company" data-kind="bg" value="#ffffff" title="Background color">
+          <div class="item-color-swatch" id="companyTextColor" data-item="company" data-kind="text" style="background:#ff0000" title="Text color"><div class="palette-popup"></div></div>
+          <div class="item-color-swatch" id="companyBgColor" data-item="company" data-kind="bg" style="background:#ffffff" title="Background color"><div class="palette-popup"></div></div>
         </div>
       </div>
 
@@ -557,8 +582,8 @@ input:focus, select:focus {
       <div class="input-with-colors">
         <input type="text" id="badgeExtra" placeholder="@handle or hashtag" value="@flutterdev">
         <div class="item-color-group">
-          <input type="color" class="item-color-picker" id="extraTextColor" data-item="extra" data-kind="text" value="#e94560" title="Text color">
-          <input type="color" class="item-color-picker" id="extraBgColor" data-item="extra" data-kind="bg" value="#ffffff" title="Background color">
+          <div class="item-color-swatch" id="extraTextColor" data-item="extra" data-kind="text" style="background:#ff0000" title="Text color"><div class="palette-popup"></div></div>
+          <div class="item-color-swatch" id="extraBgColor" data-item="extra" data-kind="bg" style="background:#ffffff" title="Background color"><div class="palette-popup"></div></div>
         </div>
       </div>
 
@@ -580,9 +605,9 @@ input:focus, select:focus {
       </div>
 
       <label>Accent Color</label>
-      <div class="color-row">
-        <button class="color-btn active" data-color="#e94560" style="background:#e94560" title="Red"></button>
-        <button class="color-btn" data-color="#f5c518" style="background:#f5c518" title="Yellow"></button>
+      <div class="color-row" id="accentColorRow">
+        <button class="color-btn active" data-color="#ff0000" style="background:#ff0000" title="Red"></button>
+        <button class="color-btn" data-color="#ffff00" style="background:#ffff00" title="Yellow"></button>
         <button class="color-btn" data-color="#000000" style="background:#000000; border:1px solid #555" title="Black"></button>
         <button class="color-btn" data-color="#ffffff" style="background:#ffffff" title="White"></button>
       </div>


### PR DESCRIPTION
## Fix: Badge color selection constrained to palette

### Problem
The text item color pickers (`<input type="color">`) allowed selecting any arbitrary color, but the e-paper badge only supports a limited palette (BW: black/white, BWR: +red, BWYR: +yellow+red).

### Changes
- **Replaced** the browser's native color picker inputs with custom **palette-constrained swatch selectors**
- Clicking a swatch opens a small popup showing **only the colors available in the current palette**
- When the **palette changes** (BW ↔ BWR ↔ BWYR), all selected text/background colors automatically **snap to the nearest available palette color**
- The **accent color row** also dynamically updates to show only palette-available colors
- Fixed initial default colors from non-palette values (e.g. `#e94560` → `#ff0000`, `#333333` → `#000000`)

### Files changed
- `projects/badge/index.html` — Replaced `<input type="color">` with custom `.item-color-swatch` elements + popup UI
- `projects/badge/badge.js` — Added palette color helpers (`rgbToHex`, `snapToNearestPaletteColor`, `refreshAllSwatches`, `rebuildAccentRow`, `buildPalettePopup`) and updated event handlers

---
*Created by Claude agent*