### PR TITLE
Fix #69: Claude on status page

### DIFF
--- a/issues/issue-69.md
+++ b/issues/issue-69.md
@@ -1,0 +1,9 @@
+# Issue 69: Claude on status page
+
+Add Claude instance count and history graph to the status page.
+
+## Status: Complete
+
+## Changes
+- `projects/status-page/server.py`: Added `get_claude_count()` using `pgrep -c claude`, added history buffer and collector flush for claude instances (1-minute intervals, 1-hour history)
+- `projects/status-page/index.html`: Added "Claude Instances" card with live count and canvas graph

--- a/projects/status-page/index.html
+++ b/projects/status-page/index.html
@@ -95,6 +95,13 @@
             <canvas class="graph" id="g-disk"></canvas>
             <div class="period">1 day</div>
         </div>
+        <div class="card">
+            <div class="lbl">Claude Instances</div>
+            <div class="val" id="claude-val">—</div>
+            <div class="det" id="claude-det">running processes</div>
+            <canvas class="graph" id="g-claude"></canvas>
+            <div class="period">1 hour</div>
+        </div>
     </div>
 
     <div class="footer">
@@ -138,9 +145,15 @@
             $('disk-bar').style.width = dk.percent_used + '%';
             $('disk-bar').style.background = clr(dk.percent_used, 70, 90);
 
+            var claude = sys.claude;
+            $('claude-val').textContent = claude.count;
+            $('claude-val').style.color = claude.count > 0 ? '#4caf50' : '#777';
+            $('claude-det').textContent = claude.count === 1 ? '1 running process' : claude.count + ' running processes';
+
             drawGraph('g-cpu', d.history.cpu, '#2196f3', {});
             drawGraph('g-mem', d.history.memory, '#ff9800', {yMin: 0, yMax: 100});
             drawGraph('g-disk', d.history.disk, '#9c27b0', {yMin: 0, yMax: 100});
+            drawGraph('g-claude', d.history.claude, '#00bcd4', {yMin: 0, intY: true});
         }
 
         function drawGraph(id, data, color, opts) {
@@ -212,8 +225,9 @@
             ctx.fillStyle = '#555';
             ctx.font = '9px monospace';
             ctx.textAlign = 'right';
-            ctx.fillText(yMx.toFixed(1), W - 2, pad.t + 9);
-            ctx.fillText(yMn.toFixed(1), W - 2, pad.t + pH);
+            var fmt = opts.intY ? function(v) { return Math.round(v).toString(); } : function(v) { return v.toFixed(1); };
+            ctx.fillText(fmt(yMx), W - 2, pad.t + 9);
+            ctx.fillText(fmt(yMn), W - 2, pad.t + pH);
 
             ctx.fillStyle = '#444';
             ctx.font = '9px monospace';

--- a/projects/status-page/server.py
+++ b/projects/status-page/server.py
@@ -30,16 +30,19 @@ SERVICES = [
 HISTORY_SIZE_CPU = 60       # 10 min at 10s intervals
 HISTORY_SIZE_MEM = 60       # 1 hour at 1 min intervals
 HISTORY_SIZE_DISK = 288     # 1 day at 5 min intervals
+HISTORY_SIZE_CLAUDE = 60    # 1 hour at 1 min intervals
 
 history_cpu = deque(maxlen=HISTORY_SIZE_CPU)
 history_mem = deque(maxlen=HISTORY_SIZE_MEM)
 history_disk = deque(maxlen=HISTORY_SIZE_DISK)
+history_claude = deque(maxlen=HISTORY_SIZE_CLAUDE)
 history_lock = Lock()
 
 # Accumulators for aggregating samples
 cpu_samples = []
 mem_samples = []
 disk_samples = []
+claude_samples = []
 sample_lock = Lock()
 
 
@@ -116,6 +119,18 @@ def get_disk():
         return {"total_gb": 0, "used_gb": 0, "percent_used": 0}
 
 
+def get_claude_count():
+    """Count running Claude instances."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-c", "claude"],
+            capture_output=True, text=True, timeout=5
+        )
+        return int(result.stdout.strip()) if result.returncode == 0 else 0
+    except Exception:
+        return 0
+
+
 def check_service(svc):
     """Check if a service is running."""
     name, path, check_type, target = svc
@@ -148,11 +163,13 @@ def get_status_data():
     cpu = get_cpu()
     mem = get_memory()
     disk = get_disk()
+    claude_count = get_claude_count()
 
     with history_lock:
         h_cpu = list(history_cpu)
         h_mem = list(history_mem)
         h_disk = list(history_disk)
+        h_claude = list(history_claude)
 
     return {
         "hostname": HOSTNAME,
@@ -163,11 +180,13 @@ def get_status_data():
             "cpu": cpu,
             "memory": mem,
             "disk": disk,
+            "claude": {"count": claude_count},
         },
         "history": {
             "cpu": h_cpu,
             "memory": h_mem,
             "disk": h_disk,
+            "claude": h_claude,
         },
     }
 
@@ -177,6 +196,7 @@ def collector_loop():
     last_cpu_flush = time.time()
     last_mem_flush = time.time()
     last_disk_flush = time.time()
+    last_claude_flush = time.time()
 
     while True:
         now = time.time()
@@ -186,11 +206,13 @@ def collector_loop():
         cpu = get_cpu()
         mem = get_memory()
         disk = get_disk()
+        claude_count = get_claude_count()
 
         with sample_lock:
             cpu_samples.append(cpu["load_1m"])
             mem_samples.append(mem["percent_used"])
             disk_samples.append(disk["percent_used"])
+            claude_samples.append(claude_count)
 
         # Flush CPU every 10 seconds
         if now - last_cpu_flush >= 10:
@@ -224,6 +246,17 @@ def collector_loop():
                 with history_lock:
                     history_disk.append(entry)
             last_disk_flush = now
+
+        # Flush claude every 60 seconds
+        if now - last_claude_flush >= 60:
+            with sample_lock:
+                samples = list(claude_samples)
+                claude_samples.clear()
+            if samples:
+                entry = [ts_short, min(samples), max(samples), round(sum(samples) / len(samples), 1)]
+                with history_lock:
+                    history_claude.append(entry)
+            last_claude_flush = now
 
         time.sleep(5)
 


### PR DESCRIPTION
## Added Claude instance count and graph to status page

### Changes
- **Backend (`server.py`)**: Added `get_claude_count()` function that uses `pgrep -c claude` to count running Claude processes. Added history tracking with samples every 5 seconds, flushed to a 60-entry buffer every 60 seconds (1 hour of history).
- **Frontend (`index.html`)**: Added a "Claude Instances" card in the metrics grid showing:
  - Current count of running Claude processes
  - Color-coded value (green when active, grey when zero)
  - Canvas graph showing instance count over the past hour (cyan `#00bcd4`)
  - Integer-formatted Y-axis labels

### How to test
Visit [ai.memention.net/status](https://ai.memention.net/status) — the new "Claude Instances" card will appear in the metrics grid alongside CPU, Memory, and Disk. The graph will populate after a few minutes of data collection.

---
*Created by Claude agent*