### PR TITLE
Fix #73: Update status

### DIFF
--- a/projects/status-page/server.py
+++ b/projects/status-page/server.py
@@ -19,11 +19,6 @@ SERVICES = [
     ("Webhook", "/webhook", "port", 5000),
     ("Status Page", "/status", "port", 5001),
     ("Todo API", "/todo-api", "port", 5003),
-    ("Todo App", "/todo-app", "file", "todo-app/build/web"),
-    ("Flutter Demo", "/flutter_demo", "file", "flutter_demo/build/web"),
-    ("Scramble", "/scramble", "file", "scramble"),
-    ("Breakout", "/breakout", "file", "breakout"),
-    ("Badge", "/badge", "file", "badge"),
 ]
 
 # History buffers: each entry is [time_label, min, max, avg]


### PR DESCRIPTION
## Summary

Removed static page entries from the status page's services list. The services section now only shows services that run as actual servers (port-based):

- **Webhook** (`/webhook`, port 5000)
- **Status Page** (`/status`, port 5001)  
- **Todo API** (`/todo-api`, port 5003)

The following static pages were removed from the services display:
- Todo App, Flutter Demo, Scramble, Breakout, Badge

**Change:** `projects/status-page/server.py` — removed 5 file-based entries from the `SERVICES` list.

---
*Created by Claude agent*