### PR TITLE
Fix #77: "WW3 on hold"

### DIFF
--- a/issues/issue-77.md
+++ b/issues/issue-77.md
@@ -1,0 +1,5 @@
+# Issue 77: WW3 on hold
+
+## Status: Done
+
+Added a tilted "WW3 ON HOLD" hazard-style banner over the countdown page at `/trumps48hours`. The banner uses a yellow/black hazard stripe design, rotated -18deg, with "Ultimatum withdrawn — stand down" subtitle. The countdown remains visible but dimmed behind the banner.

--- a/projects/trumps48hours/index.html
+++ b/projects/trumps48hours/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>T-Minus Countdown</title>
+<title>WW3 ON HOLD — T-Minus Countdown</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Rajdhani:wght@300;500;700&display=swap');
 
@@ -300,9 +300,85 @@
     margin-top: 2rem;
     letter-spacing: 0.2em;
   }
+
+  /* WW3 ON HOLD banner */
+  .on-hold-banner {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(-18deg);
+    z-index: 100;
+    pointer-events: none;
+    width: 110vw;
+    text-align: center;
+    padding: 1.2rem 0;
+    background: repeating-linear-gradient(
+      45deg,
+      rgba(255,200,0,0.92),
+      rgba(255,200,0,0.92) 30px,
+      rgba(20,20,20,0.95) 30px,
+      rgba(20,20,20,0.95) 60px
+    );
+    border-top: 6px solid #111;
+    border-bottom: 6px solid #111;
+    box-shadow:
+      0 0 60px rgba(255,200,0,0.4),
+      0 0 120px rgba(255,200,0,0.15),
+      inset 0 0 30px rgba(0,0,0,0.3);
+    animation: bannerAppear 0.8s ease-out, bannerGlow 3s ease-in-out 0.8s infinite;
+  }
+
+  .on-hold-banner-text {
+    font-family: 'Orbitron', monospace;
+    font-weight: 900;
+    font-size: clamp(2.5rem, 8vw, 5.5rem);
+    color: #111;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    text-shadow:
+      2px 2px 0 rgba(255,200,0,0.6),
+      -1px -1px 0 rgba(255,200,0,0.3);
+    background: rgba(255,200,0,0.95);
+    display: inline-block;
+    padding: 0.15em 0.6em;
+    border-radius: 4px;
+  }
+
+  .on-hold-sub {
+    font-family: 'Rajdhani', sans-serif;
+    font-weight: 700;
+    font-size: clamp(0.9rem, 2.5vw, 1.4rem);
+    color: #ffc800;
+    letter-spacing: 0.4em;
+    text-transform: uppercase;
+    margin-top: 0.3rem;
+    text-shadow: 0 0 10px rgba(255,200,0,0.8);
+  }
+
+  @keyframes bannerAppear {
+    0% { transform: translate(-50%, -50%) rotate(-18deg) scaleY(0); opacity: 0; }
+    60% { transform: translate(-50%, -50%) rotate(-18deg) scaleY(1.1); opacity: 1; }
+    100% { transform: translate(-50%, -50%) rotate(-18deg) scaleY(1); opacity: 1; }
+  }
+
+  @keyframes bannerGlow {
+    0%, 100% { box-shadow: 0 0 60px rgba(255,200,0,0.4), 0 0 120px rgba(255,200,0,0.15), inset 0 0 30px rgba(0,0,0,0.3); }
+    50% { box-shadow: 0 0 80px rgba(255,200,0,0.6), 0 0 160px rgba(255,200,0,0.25), inset 0 0 30px rgba(0,0,0,0.3); }
+  }
+
+  /* Dim the countdown behind the banner */
+  .bg-grid, .glow, .container, .particles {
+    opacity: 0.35;
+  }
 </style>
 </head>
 <body>
+
+<!-- WW3 ON HOLD banner -->
+<div class="on-hold-banner">
+  <div class="on-hold-banner-text">⚠ WW3 ON HOLD ⚠</div>
+  <div class="on-hold-sub">Ultimatum withdrawn — stand down</div>
+</div>
 
 <div class="bg-grid"></div>
 <div class="glow"></div>


### PR DESCRIPTION
## ⚠️ WW3 ON HOLD — Banner Added

Added a large, tilted hazard-stripe banner overlaying the countdown page at `/trumps48hours`:

- **Banner text**: "⚠ WW3 ON HOLD ⚠" in bold Orbitron font
- **Subtitle**: "Ultimatum withdrawn — stand down"
- **Design**: Yellow/black hazard stripe background, rotated -18°, with animated glow effect and entrance animation
- **Countdown**: Still visible but dimmed (35% opacity) behind the banner
- **Page title**: Updated to "WW3 ON HOLD — T-Minus Countdown"

The banner uses a construction/hazard tape aesthetic with repeating diagonal stripes, solid black borders, and a pulsing glow — matching the serious-but-stood-down tone.

---
*Created by Claude agent*