### PR TITLE
Fix #81: Fix todo app

### DIFF
--- a/projects/todo-app/README.md
+++ b/projects/todo-app/README.md
@@ -43,6 +43,9 @@ lib/
 
 ## Build
 
+> **⚠️ IMPORTANT:** This app is served at `/todo-app/` behind nginx. You **must**
+> use `--base-href /todo-app/` when building, otherwise all asset paths will break.
+
 ```bash
 flutter pub get
 flutter build web --base-href /todo-app/ --release

--- a/projects/todo-app/build/web/.last_build_id
+++ b/projects/todo-app/build/web/.last_build_id
@@ -1,1 +1,1 @@
-739fdb72b5e622f8dd772e874d0e151d
+6dcfdcecab47140b48d702da9f4aeb4b

--- a/projects/todo-app/build/web/flutter_bootstrap.js
+++ b/projects/todo-app/build/web/flutter_bootstrap.js
@@ -37,6 +37,6 @@ _flutter.buildConfig = {"engineRevision":"e4b8dca3f1b4ede4c30371002441c88c12187e
 
 _flutter.loader.load({
   serviceWorkerSettings: {
-    serviceWorkerVersion: "1248084584" /* Flutter's service worker is deprecated and will be removed in a future Flutter release. */
+    serviceWorkerVersion: "722889761" /* Flutter's service worker is deprecated and will be removed in a future Flutter release. */
   }
 });

--- a/projects/todo-app/build/web/index.html
+++ b/projects/todo-app/build/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="/">
+  <base href="/todo-app/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
## Fix: Todo app broken asset paths

**Problem:** The todo app was built with `<base href="/">` (the default) instead of `<base href="/todo-app/">`. Since the app is served at `/todo-app/` via nginx, all JavaScript and asset paths resolved to the root, causing `flutter_bootstrap.js` and `manifest.json` to fail to load.

**Fix:**
- Rebuilt the Flutter web app with `flutter build web --base-href=/todo-app/`
- Added a prominent warning in the README to prevent this from happening again:
  > ⚠️ IMPORTANT: This app is served at `/todo-app/` behind nginx. You **must** use `--base-href /todo-app/` when building.

**Files changed:**
- `projects/todo-app/build/web/index.html` — now has `<base href="/todo-app/">`
- `projects/todo-app/build/web/flutter_bootstrap.js` — rebuilt
- `projects/todo-app/README.md` — added build warning

---
*Created by Claude agent*