### PR TITLE
Fix #87: Todo app: move delete item to edit dialog

### DIFF
--- a/projects/todo-app/lib/screens/todo_list_screen.dart
+++ b/projects/todo-app/lib/screens/todo_list_screen.dart
@@ -42,35 +42,15 @@ class _TodoListScreenState extends State<TodoListScreen> {
       builder: (context) => EditTodoDialog(todo: todo),
     );
     if (result != null && mounted) {
-      await context.read<TodoProvider>().updateTodo(
-            todo.id,
-            title: result['title'],
-            description: result['description'],
-          );
-    }
-  }
-
-  Future<void> _deleteTodo(Todo todo) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Delete Todo'),
-        content: Text('Delete "${todo.title}"?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed == true && mounted) {
-      await context.read<TodoProvider>().deleteTodo(todo.id);
+      if (result['action'] == 'delete') {
+        await context.read<TodoProvider>().deleteTodo(todo.id);
+      } else if (result['action'] == 'save') {
+        await context.read<TodoProvider>().updateTodo(
+              todo.id,
+              title: result['title'],
+              description: result['description'],
+            );
+      }
     }
   }
 
@@ -179,7 +159,6 @@ class _TodoListScreenState extends State<TodoListScreen> {
           index: index,
           onToggle: () => todoProvider.toggleDone(todo),
           onEdit: () => _editTodo(todo),
-          onDelete: () => _deleteTodo(todo),
           onUpdateDescription: (newDesc) {
             todoProvider.updateTodo(todo.id, description: newDesc);
           },

--- a/projects/todo-app/lib/widgets/edit_todo_dialog.dart
+++ b/projects/todo-app/lib/widgets/edit_todo_dialog.dart
@@ -32,9 +32,34 @@ class _EditTodoDialogState extends State<EditTodoDialog> {
   void _submit() {
     if (!_formKey.currentState!.validate()) return;
     Navigator.pop(context, {
+      'action': 'save',
       'title': _titleController.text.trim(),
       'description': _descriptionController.text.trim(),
     });
+  }
+
+  Future<void> _confirmDelete() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Todo'),
+        content: Text('Delete "${widget.todo.title}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      Navigator.pop(context, {'action': 'delete'});
+    }
   }
 
   @override
@@ -74,6 +99,12 @@ class _EditTodoDialogState extends State<EditTodoDialog> {
         ),
       ),
       actions: [
+        TextButton(
+          onPressed: _confirmDelete,
+          style: TextButton.styleFrom(foregroundColor: Colors.red),
+          child: const Text('Delete'),
+        ),
+        const Spacer(),
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('Cancel'),

--- a/projects/todo-app/lib/widgets/todo_tile.dart
+++ b/projects/todo-app/lib/widgets/todo_tile.dart
@@ -53,7 +53,6 @@ class TodoTile extends StatefulWidget {
   final int index;
   final VoidCallback onToggle;
   final VoidCallback onEdit;
-  final VoidCallback onDelete;
   final ValueChanged<String>? onUpdateDescription;
 
   const TodoTile({
@@ -62,7 +61,6 @@ class TodoTile extends StatefulWidget {
     required this.index,
     required this.onToggle,
     required this.onEdit,
-    required this.onDelete,
     this.onUpdateDescription,
   });
 
@@ -148,11 +146,6 @@ class _TodoTileState extends State<TodoTile> {
                   icon: const Icon(Icons.edit_outlined, size: 20),
                   tooltip: 'Edit',
                   onPressed: widget.onEdit,
-                ),
-                IconButton(
-                  icon: Icon(Icons.delete_outline, size: 20, color: Colors.red.shade400),
-                  tooltip: 'Delete',
-                  onPressed: widget.onDelete,
                 ),
                 ReorderableDragStartListener(
                   index: widget.index,


### PR DESCRIPTION
## Summary

Moved the delete button from the todo list tile into the edit dialog, as requested.

### Changes made:

- **`edit_todo_dialog.dart`**: Added a red "Delete" button on the left side of the dialog actions. It shows a confirmation dialog before deleting, preserving the same safety UX as before.
- **`todo_tile.dart`**: Removed the delete icon button from each todo tile's trailing actions, and removed the now-unused `onDelete` callback property.
- **`todo_list_screen.dart`**: Updated `_editTodo()` to handle both `save` and `delete` actions returned from the edit dialog. Removed the standalone `_deleteTodo()` method.

### How it works now:
1. User taps the edit (pencil) icon on a todo
2. The edit dialog shows with **Delete** (red, left side), **Cancel**, and **Save** buttons
3. Tapping Delete shows a confirmation dialog before proceeding
4. The todo list tile is cleaner with one fewer button per row

Build verified successfully with `flutter build web`.

---
*Created by Claude agent*