### PR TITLE
Fix #93: Fix readme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ graph TD
     K --> L[Validate Flutter build]
     L --> M[Build succeeds/fails]
 
-    style H fill:#4FC3F7
-    style G fill:#81C784
-    style L fill:#FFB74D
+    style H fill:#4FC3F7,color:#000
+    style G fill:#81C784,color:#000
+    style L fill:#FFB74D,color:#000
 ```
 
 **Key points:**


### PR DESCRIPTION
## Fix: Mermaid diagram text colors for dark mode

The mermaid diagram in `README.md` had three styled nodes with light fill colors (`#4FC3F7`, `#81C784`, `#FFB74D`) but no explicit text color. In GitHub's dark mode, mermaid defaults text to white, making it unreadable against these light backgrounds.

**Fix:** Added `color:#000` to all three styled nodes to ensure black text on light backgrounds, which works well in both light and dark mode.

```diff
-    style H fill:#4FC3F7
-    style G fill:#81C784
-    style L fill:#FFB74D
+    style H fill:#4FC3F7,color:#000
+    style G fill:#81C784,color:#000
+    style L fill:#FFB74D,color:#000
```

---
*Created by Claude agent*