### PR TITLE
Fix #97: Time is off

### DIFF
--- a/projects/trumps48hours/index.html
+++ b/projects/trumps48hours/index.html
@@ -351,12 +351,12 @@
 
   <div class="done-message" id="doneMsg">TARGET REACHED</div>
 
-  <div class="target-info">TARGET: 2026-04-09 00:00:00 GMT</div>
+  <div class="target-info">TARGET: 2026-04-08 00:00:00 GMT</div>
 </div>
 
 <script>
-  // Target: April 9, 2026 at 00:00:00 GMT (20:00 EDT Tuesday April 8)
-  const TARGET = Date.UTC(2026, 3, 9, 0, 0, 0, 0); // month is 0-indexed
+  // Target: April 8, 2026 at 00:00:00 GMT (20:00 EDT Tuesday April 7)
+  const TARGET = Date.UTC(2026, 3, 8, 0, 0, 0, 0); // month is 0-indexed
   // We'll estimate a "start" as 48h before target for progress bar
   const TOTAL_DURATION = 48 * 60 * 60 * 1000; // 48 hours in ms
   const START = TARGET - TOTAL_DURATION;


### PR DESCRIPTION
## Fix: Corrected countdown target date

The countdown target was set to **April 9, 2026 00:00 GMT** but the actual deadline ("20:00 Washington DC time on Tuesday") corresponds to **April 8, 2026 00:00 GMT** — exactly 24 hours earlier.

### Changes
- Updated `TARGET` in `projects/trumps48hours/index.html` from `Date.UTC(2026, 3, 9, ...)` to `Date.UTC(2026, 3, 8, ...)`
- Updated the displayed target info text to match

The countdown should now end tonight as expected.

---
*Created by Claude agent*