### PR TITLE
Fix #99: Status CORS?

### DIFF
--- a/issues/issue-99.md
+++ b/issues/issue-99.md
@@ -1,0 +1,12 @@
+# Issue 99: Status CORS / iframe fix
+
+## Problem
+The status page at /status was blocked from being embedded in iframes on other pages due to the global X-Frame-Options: SAMEORIGIN header set in nginx.conf.
+
+## Solution
+Overrode the X-Frame-Options header in the /status nginx location block to allow iframe embedding, while preserving other security headers.
+
+## Changes
+- Modified /etc/nginx/sites-available/ai.memention.net: added add_header directives to the /status location block to clear X-Frame-Options while keeping X-Content-Type-Options and Strict-Transport-Security.
+
+## Status: DONE


### PR DESCRIPTION
## Fix: Allow status page iframe embedding

**Problem:** The `/status` page couldn't be shown in an iframe on other pages because the global nginx config set `X-Frame-Options: SAMEORIGIN`, blocking cross-origin framing.

**Solution:** Overrode the `X-Frame-Options` header in the nginx `/status` location block to allow iframe embedding. Other security headers (`X-Content-Type-Options: nosniff`, `Strict-Transport-Security`) are preserved.

**What changed:**
- `/etc/nginx/sites-available/ai.memention.net` — added `add_header` directives to the `/status` location block that clear `X-Frame-Options` while keeping other security headers

**Verification:**
- `curl -sI https://ai.memention.net/status` no longer returns `X-Frame-Options: SAMEORIGIN`
- The status page, JSON endpoint, and SSE stream are all iframe-embeddable

---
*Created by Claude agent*