### PR TITLE
Fix #101: Long press drag

### DIFF
--- a/projects/todo-app/lib/widgets/todo_tile.dart
+++ b/projects/todo-app/lib/widgets/todo_tile.dart
@@ -88,7 +88,7 @@ class _TodoTileState extends State<TodoTile> {
     final hasSubCheckboxes = counts.total > 0;
     final allSubsDone = hasSubCheckboxes && counts.checked == counts.total;
 
-    return Card(
+    final card = Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -176,11 +176,6 @@ class _TodoTileState extends State<TodoTile> {
                   tooltip: 'Edit',
                   onPressed: widget.onEdit,
                 ),
-                if (widget.reorderable)
-                  ReorderableDragStartListener(
-                    index: widget.index,
-                    child: const Icon(Icons.drag_handle, size: 20),
-                  ),
               ],
             ),
             onTap: (hasDescription || hasImages)
@@ -208,6 +203,14 @@ class _TodoTileState extends State<TodoTile> {
         ],
       ),
     );
+
+    if (widget.reorderable) {
+      return ReorderableDelayedDragStartListener(
+        index: widget.index,
+        child: card,
+      );
+    }
+    return card;
   }
 
   Widget _buildImageGrid(BuildContext context) {


### PR DESCRIPTION
## Long press to drag for todo reordering

**What changed:**
- Removed the visible drag handle icon (`Icons.drag_handle`) from each todo tile's trailing actions
- Wrapped the entire todo card with `ReorderableDelayedDragStartListener` so that **long-pressing** anywhere on a todo card activates drag-to-reorder
- Archive tab tiles (non-reorderable) remain unchanged — no drag behavior

**How it works:**
- Long press and hold on any todo item to start dragging
- Drag to the desired position and release to reorder
- The drag handle icon is no longer shown, keeping the UI cleaner

**Files changed:**
- `projects/todo-app/lib/widgets/todo_tile.dart`

---
*Created by Claude agent*