### PR TITLE
Fix #103: Fix longpress to reorder

### DIFF
--- a/projects/todo-app/lib/screens/todo_list_screen.dart
+++ b/projects/todo-app/lib/screens/todo_list_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
@@ -238,6 +240,27 @@ class _TodoListScreenState extends State<TodoListScreen> {
       padding: const EdgeInsets.only(top: 8, bottom: 88),
       itemCount: todoProvider.todos.length,
       buildDefaultDragHandles: false,
+      proxyDecorator: (child, index, animation) {
+        return AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) {
+            final animValue = Curves.easeInOut.transform(animation.value);
+            final elevation = lerpDouble(0, 8, animValue)!;
+            final scale = lerpDouble(1, 1.03, animValue)!;
+            return Transform.scale(
+              scale: scale,
+              child: Material(
+                elevation: elevation,
+                color: Colors.transparent,
+                shadowColor: Theme.of(context).colorScheme.shadow,
+                borderRadius: BorderRadius.circular(12),
+                child: child,
+              ),
+            );
+          },
+          child: child,
+        );
+      },
       onReorder: (oldIndex, newIndex) {
         todoProvider.reorder(oldIndex, newIndex);
       },

--- a/projects/todo-app/web/index.html
+++ b/projects/todo-app/web/index.html
@@ -49,7 +49,18 @@
         background-color: #FFFBFE;
       }
     }
+    /* Prevent browser default behaviors that interfere with long-press drag */
+    body {
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      user-select: none;
+      touch-action: pan-y;
+    }
   </style>
+  <script>
+    // Prevent browser context menu on long press (mobile web)
+    document.addEventListener('contextmenu', function(e) { e.preventDefault(); });
+  </script>
 </head>
 <body>
   <!--


### PR DESCRIPTION
## Fix: Long-press to reorder on mobile web

The `ReorderableDelayedDragStartListener` was already in place but wasn't working on mobile web because **the browser's default context menu was intercepting long-press gestures** before Flutter's gesture recognizer could detect them.

### Changes made:

**`projects/todo-app/web/index.html`**
- Added `contextmenu` event prevention to stop the browser's long-press menu from interfering
- Added CSS `user-select: none` and `-webkit-touch-callout: none` to prevent text selection and iOS callout menus
- Added `touch-action: pan-y` to allow vertical scrolling while preventing other browser touch behaviors

**`projects/todo-app/lib/screens/todo_list_screen.dart`**
- Added `proxyDecorator` to `ReorderableListView.builder` with elevation and subtle scale animation, giving clear visual feedback when an item is being dragged
- No drag handle icon needed — long press initiates reorder directly

### How to test:
1. Open the todo app on a mobile browser
2. Long-press any todo item (~500ms)
3. The item should lift with elevation/shadow and become draggable
4. Drag to reorder and release

---
*Created by Claude agent*