### PR TITLE
Default Bellman to Swedish

### DIFF
--- a/projects/bellman/index.html
+++ b/projects/bellman/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="sv">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />

--- a/projects/bellman/scripts/i18n.js
+++ b/projects/bellman/scripts/i18n.js
@@ -12,8 +12,8 @@
  *              mix monolingual and bilingual fields in the same record
  *              during partial migrations).
  *
- * Locale persists to localStorage. On first load we sniff `navigator.language`
- * and default to Swedish for `sv*` locales, otherwise English.
+ * Locale persists to localStorage. On first load we default to Swedish;
+ * users can switch to English via the footer toggle and the choice persists.
  *
  * Renderers don't subscribe individually — `setLocale` dispatches a
  * `localechange` event on `window`, and `app.js` simply re-renders the
@@ -28,11 +28,7 @@ function detectInitial() {
     const v = localStorage.getItem(STORAGE_KEY);
     if (SUPPORTED.includes(v)) return v;
   } catch {/* ignore */}
-  try {
-    const nav = (navigator.language || 'en').toLowerCase();
-    if (nav.startsWith('sv')) return 'sv';
-  } catch {/* ignore */}
-  return 'en';
+  return 'sv';
 }
 
 let _locale = detectInitial();


### PR DESCRIPTION
## Summary
- First-time visitors to `/bellman/` now load in Swedish instead of English.
- `detectInitial()` no longer sniffs `navigator.language`; it just defaults to `'sv'` if no localStorage choice is set.
- `<html lang>` switched to `sv` so screen readers and the spellchecker pick the right language out of the gate.
- The footer EN/SV toggle still works; user choice persists in localStorage.

## Test plan
- [ ] In an incognito window, visit https://ai.memention.net/bellman/ — text renders in Swedish
- [ ] Click EN in the footer — switches to English, persists across reload
- [ ] Click SV — switches back, persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)