### PR TITLE
Fix Bellman QR page: nginx .mjs MIME + hardcoded base

### DIFF
--- a/projects/bellman/qr-codes.html
+++ b/projects/bellman/qr-codes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="sv">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -289,7 +289,7 @@
       <label for="base-url" style="font-size: 0.85rem; color: #b8a684;">
         Base URL:
       </label>
-      <input id="base-url" type="url" placeholder="https://your-deployed-site.example" />
+      <input id="base-url" type="url" placeholder="https://ai.memention.net/bellman" />
       <button id="apply-btn" type="button">Apply &amp; regenerate</button>
       <button id="print-btn" type="button">🖨  Print</button>
       <a href="index.html">← Back to game</a>
@@ -346,21 +346,14 @@
 
     const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V'];
 
-    function defaultBase() {
-      // If served over file:// or as an offline asset, fall back to a generic placeholder.
-      if (location.protocol === 'file:' || location.origin === 'null') {
-        return 'https://stockholm-mystery.example';
-      }
-      // Strip the file part — keep only origin + (any path prefix to the app).
-      const url = new URL('.', location.href);
-      // Normalise: drop trailing slashes; the URL builder re-adds the right separators.
-      return url.toString().replace(/\/+$/, '');
-    }
+    // Production deployment URL. The toolbar still lets you override it for
+    // local testing or future moves.
+    const DEFAULT_BASE = 'https://ai.memention.net/bellman';
 
     function buildUrl(base, stopId) {
       // QR codes encode #/stop/<id> against whichever base the operator uses.
       const trimmed = base.replace(/\/+$/, '');
-      return `${trimmed}/index.html#/stop/${stopId}`;
+      return `${trimmed}/#/stop/${stopId}`;
     }
 
     function makeQrSvg(text) {
@@ -413,16 +406,15 @@
     }
 
     // Initial population.
-    const initialBase = defaultBase();
-    baseInput.value = initialBase;
+    baseInput.value = DEFAULT_BASE;
     originHint.textContent =
-      `QR codes currently encode: ${initialBase}/index.html#/stop/<id>`;
-    renderCards(initialBase);
+      `QR codes currently encode: ${DEFAULT_BASE}/#/stop/<id>`;
+    renderCards(DEFAULT_BASE);
 
     // User overrides the base URL.
     applyBtn.addEventListener('click', () => {
-      const v = (baseInput.value || '').trim() || initialBase;
-      originHint.textContent = `QR codes currently encode: ${v}/index.html#/stop/<id>`;
+      const v = (baseInput.value || '').trim() || DEFAULT_BASE;
+      originHint.textContent = `QR codes currently encode: ${v}/#/stop/<id>`;
       renderCards(v);
     });
     baseInput.addEventListener('keydown', (e) => {

--- a/setup-server.sh
+++ b/setup-server.sh
@@ -72,6 +72,12 @@ sudo -u "$WEBHOOK_USER" bash "$REPO_DIR/setup-hooks.sh"
 echo ""
 echo "--- Configuring nginx ---"
 cp "$REPO_DIR/nginx/security-headers.conf" /etc/nginx/snippets/security-headers.conf
+
+# Map .mjs to application/javascript so ES module scripts load under
+# strict-MIME browsers. Default nginx mime.types only covers .js.
+if ! grep -qE 'js[[:space:]]+mjs;' /etc/nginx/mime.types; then
+    sed -i 's|application/javascript\([[:space:]]*\)js;|application/javascript\1js mjs;|' /etc/nginx/mime.types
+fi
 cat > /etc/nginx/sites-available/ai.memention.net <<'NGINX'
 server {
     listen 80;


### PR DESCRIPTION
## Summary
- **Root cause**: `vendor/qrcode-generator.mjs` was served with `Content-Type: application/octet-stream`. Chrome (under strict MIME checking, which we have via `X-Content-Type-Options: nosniff`) refuses to execute module scripts with the wrong type — so the script silently failed and zero cards rendered. Default nginx `mime.types` doesn't list `.mjs`.
- **Server fix** (already applied on live host): added `mjs` to the `application/javascript` mapping in `/etc/nginx/mime.types` and restarted nginx.
- **Repo capture**: `setup-server.sh` now patches `mime.types` the same way, so a fresh provisioning keeps it fixed. Backup of the original file lives at `/etc/nginx/mime.types.bak` on the server.
- **qr-codes.html cleanup** (per "baseurl is also fixed now"): default base hardcoded to `https://ai.memention.net/bellman`, encoded URL drops `/index.html` (now `<base>/#/stop/<id>`), `<html lang="sv">` for consistency. The toolbar input still allows override for local/dev use.

## Verification
Live render via headless Chromium after the nginx fix:
```
cards rendered     : 5
base-url input val : https://ai.memention.net/bellman
first encoded url  : https://ai.memention.net/bellman/index.html#/stop/engelen   (pre-merge)
```
After merge the encoded URL becomes `https://ai.memention.net/bellman/#/stop/engelen`.

## Test plan
- [ ] Visit https://ai.memention.net/bellman/qr-codes.html — five cards render
- [ ] Each card's QR encodes `https://ai.memention.net/bellman/#/stop/<id>`
- [ ] Scanning a QR opens the matching stop in the game
- [ ] Print preview still produces one card per A4 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)