### PR TITLE
Tighten Bellman QR-card print layout

### DIFF
--- a/projects/bellman/qr-codes.html
+++ b/projects/bellman/qr-codes.html
@@ -266,7 +266,6 @@
       .qr-card {
         page-break-after: always;
         break-after: page;
-        min-height: calc(100vh - 1cm);
       }
       .qr-card:last-child { page-break-after: auto; break-after: auto; }
       @page {


### PR DESCRIPTION
## Summary
- Drop `min-height: calc(100vh - 1cm)` from `.qr-card` in `@media print`. It was forcing each QR card to fill the printable area even when content was short — black border and inner gold ornament stretched to the page bottom while QR+info sat at the top.
- Cover card already lacks this rule and looked tight, which is the target.
- `page-break-after: always` still keeps one card per page.

## Test plan
- [ ] Open https://ai.memention.net/bellman/qr-codes.html, click Print
- [ ] Cover page still tight (unchanged)
- [ ] Each QR card's border now hugs the content, no empty stretch beneath
- [ ] Still one card per A4 page
- [ ] Screen layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)