### PR TITLE
Add Bellman favicon

### DIFF
--- a/projects/bellman/favicon.svg
+++ b/projects/bellman/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a0f08"/>
+  <rect x="13" y="15" width="6" height="13" fill="#e8d9b8"/>
+  <rect x="13" y="15" width="2" height="13" fill="#faf6ec"/>
+  <line x1="16" y1="12" x2="16" y2="15" stroke="#1a0f08" stroke-width="1"/>
+  <path d="M16 4 C 19 8, 19 11, 16 12.5 C 13 11, 13 8, 16 4 Z" fill="#c9461d"/>
+  <path d="M16 6 C 17.5 9, 17.5 11, 16 12 C 14.5 11, 14.5 9, 16 6 Z" fill="#c9a64a"/>
+  <ellipse cx="16" cy="9" rx="0.9" ry="1.6" fill="#faf6ec" opacity="0.6"/>
+  <ellipse cx="16" cy="29" rx="7" ry="0.8" fill="#c9461d" opacity="0.25"/>
+</svg>

--- a/projects/bellman/index.html
+++ b/projects/bellman/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="theme-color" content="#1a0f08" />
   <meta name="description" content="A mystery pub walk through the candlelit alleys of 18th-century Stockholm." />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <title>The Stockholm Mystery — A Pub Walk</title>
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/projects/bellman/qr-codes.html
+++ b/projects/bellman/qr-codes.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
   <title>QR Codes — Bellman's Lost Epistle</title>
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- New `projects/bellman/favicon.svg` (~600 bytes): a candle on a dark-ink rounded square, drawn with the theme palette (ember/gold flame, parchment-cream wax). Matches the candle emoji on the landing-page card.
- Linked from `index.html` and `qr-codes.html` via `<link rel="icon" type="image/svg+xml" href="favicon.svg">`. SVG favicons are supported by all modern browsers; older ones just fall back to the default.

## Test plan
- [ ] After merge, https://ai.memention.net/bellman/ shows a candle favicon in the tab
- [ ] /bellman/qr-codes.html does the same
- [ ] No console 404 for favicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)