### PR TITLE
Add Kanban Demo (Doodle Together) to status page and landing

### DIFF
--- a/projects/landing/index.html
+++ b/projects/landing/index.html
@@ -144,6 +144,12 @@
             <div class="desc">Chat with Stockholm public transport</div>
             <span class="badge app">APP</span>
         </a>
+        <a class="card" href="/kanban-demo/">
+            <div class="icon">&#x1F3A8;</div>
+            <div class="name"><span class="status-dot" data-path="/kanban-demo/"></span>Doodle Together</div>
+            <div class="desc">Collaborative real-time drawing rooms</div>
+            <span class="badge app">APP</span>
+        </a>
         <a class="card" href="https://github.com/epatel/vps-ai/tree/main/projects/poem" target="_blank">
             <div class="icon">&#x1F4DC;</div>
             <div class="name">Poem</div>

--- a/projects/status-page/server.py
+++ b/projects/status-page/server.py
@@ -82,6 +82,7 @@ SERVICES = [
     ("Quiz", "/quiz", "port", 8092, {"check_path": "/quiz/health"}),
     ("SL MCP", "/sl-mcp", "port", 8095, {"check_path": "/sl-mcp/"}),
     ("SL Chat", "/sl-chat", "port", 8788, {"check_path": "/sl-chat/"}),
+    ("Kanban Demo", "/kanban-demo", "port", 8096, {"check_path": "/kanban-demo/healthz"}),
     # Static file projects (check index.html exists)
     ("Scramble", "/scramble", "file", "scramble"),
     ("Badge", "/badge", "file", "badge"),


### PR DESCRIPTION
Wires the already-deployed **kanban-demo** service (Doodle Together — a FastAPI + WebSocket collaborative drawing app) into the dashboards.

## Server state (verified live)
- `kanban-demo.service` is active: uvicorn on `127.0.0.1:8096`
- nginx routes `/kanban-demo/` → 8096 (plus a WebSocket route for `…/ws`)
- `GET /kanban-demo/healthz` → `200 {"status":"ok","app":"doodle-together"}`

## Changes
- **status-page** (`projects/status-page/server.py`): new `SERVICES` entry checking port 8096, with `check_path="/kanban-demo/healthz"` so the nginx-routing probe hits a real route.
- **landing** (`projects/landing/index.html`): app card linking to `/kanban-demo/` with a live status dot (`data-path="/kanban-demo/"`).

Takes effect after merge — the post-merge hook restarts `status-page`; the landing page is static and updates on pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)